### PR TITLE
[지현] 0722

### DIFF
--- a/남지현/bruteForce/AAndB212919.java
+++ b/남지현/bruteForce/AAndB212919.java
@@ -1,0 +1,30 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 12919 - A와 B 2 (골드5)
+
+class Main {
+
+    static String S, T;
+
+    static boolean solve(String str) {
+        if (str.length() == S.length()) {
+            return S.equals(str.toString());
+        }
+        if (str.charAt(str.length()-1)=='A') {
+            if (solve(str.substring(0, str.length()-1))) return true;
+        } 
+        if (str.charAt(0) == 'B') {
+            StringBuilder sb = new StringBuilder(str);
+            if (solve(sb.deleteCharAt(0).reverse().toString())) return true;
+        }
+        return false;
+    }
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        S = bf.readLine();
+        T = bf.readLine();
+        System.out.println(solve(T)? 1: 0);
+    }
+}

--- a/남지현/dp/CypherCode2011.java
+++ b/남지현/dp/CypherCode2011.java
@@ -12,7 +12,7 @@ class Main {
     }
 
     static boolean canDecode(String str, int lastIdx) {
-        return str.charAt(lastIdx-1)=='1' || str.charAt(lastIdx-1)=='2' && str.charAt(lastIdx)>='0' && str.charAt(lastIdx)<='6';
+        return str.charAt(lastIdx-1)=='1' || str.charAt(lastIdx-1)=='2' && str.charAt(lastIdx)<='6';
     }
     
     public static void main(String[] args) throws Exception {

--- a/남지현/dp/CypherCode2011.java
+++ b/남지현/dp/CypherCode2011.java
@@ -1,0 +1,36 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 2011 - 암호코드 (골드5)
+
+class Main {
+
+    static final int MOD = 1_000_000; 
+
+    static boolean isPositiveDigit(String str, int idx) {
+        return str.charAt(idx)>'0' && str.charAt(idx)<='9';
+    }
+    
+    static boolean isAlpha(String str, int lastIdx) {
+        int ten = str.charAt(lastIdx-1)-'0';
+        int num = 10*ten+(str.charAt(lastIdx)-'0');
+        return ten>0 && num>=1 && num<=26;
+    }
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        String input = bf.readLine();
+        int[] counts = new int[input.length()+1];
+        counts[0]=1;
+        for (int i=1; i<counts.length; i++) {
+            if (isPositiveDigit(input, i-1)) {
+                counts[i] += counts[i-1];
+            }
+            if (i>=2 && isAlpha(input, i-1)) {
+                counts[i] += counts[i-2];
+            }
+            counts[i]%=MOD;
+        }
+        System.out.println(counts[input.length()]);
+    }
+}

--- a/남지현/dp/CypherCode2011.java
+++ b/남지현/dp/CypherCode2011.java
@@ -10,11 +10,9 @@ class Main {
     static boolean isPositiveDigit(String str, int idx) {
         return str.charAt(idx)>'0' && str.charAt(idx)<='9';
     }
-    
-    static boolean isAlpha(String str, int lastIdx) {
-        int ten = str.charAt(lastIdx-1)-'0';
-        int num = 10*ten+(str.charAt(lastIdx)-'0');
-        return ten>0 && num>=1 && num<=26;
+
+    static boolean canDecode(String str, int lastIdx) {
+        return str.charAt(lastIdx-1)=='1' || str.charAt(lastIdx-1)=='2' && str.charAt(lastIdx)>='0' && str.charAt(lastIdx)<='6';
     }
     
     public static void main(String[] args) throws Exception {
@@ -26,7 +24,7 @@ class Main {
             if (isPositiveDigit(input, i-1)) {
                 counts[i] += counts[i-1];
             }
-            if (i>=2 && isAlpha(input, i-1)) {
+            if (i>=2 && canDecode(input, i-1)) {
                 counts[i] += counts[i-2];
             }
             counts[i]%=MOD;

--- a/남지현/graph/ACMCraft1005.java
+++ b/남지현/graph/ACMCraft1005.java
@@ -1,0 +1,60 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 1005 - ACM Craft (골드3) 위상 정렬
+
+class Main {
+
+    static List<List<Integer>> graph;
+    static int[] costs, times, inDegree;
+    static int N;
+
+    static int solution(int destination) {
+        ArrayDeque<Integer> queue = new ArrayDeque<>();
+        for (int i=1; i<=N; i++) {
+            if (inDegree[i]==0) {
+                queue.addLast(i);
+                times[i] = costs[i];
+            }
+        }
+        while (! queue.isEmpty()) {
+            int now = queue.pollFirst();
+            for (int next: graph.get(now)) {
+                inDegree[next]--;
+                if (inDegree[next]==0) queue.addLast(next);
+                times[next] = Math.max(times[next], times[now]+costs[next]);
+            }
+        }
+        return times[destination];
+    }
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        int T = Integer.parseInt(bf.readLine());
+        StringBuilder sb = new StringBuilder();
+        for (int t=0; t<T; t++) {
+            StringTokenizer st = new StringTokenizer(bf.readLine());
+            N = Integer.parseInt(st.nextToken());
+            int K = Integer.parseInt(st.nextToken());
+            costs = new int[N+1];
+            times = new int[N+1];
+            inDegree = new int[N+1];
+            graph = new ArrayList<>();
+            st = new StringTokenizer(bf.readLine());
+            graph.add(new ArrayList<>());
+            for (int i=1; i<=N; i++) {
+                costs[i] = Integer.parseInt(st.nextToken());
+                graph.add(new ArrayList<>());
+            }
+            for (int i=0; i<K; i++) {
+                st = new StringTokenizer(bf.readLine());
+                int dep = Integer.parseInt(st.nextToken());
+                int dst = Integer.parseInt(st.nextToken());
+                graph.get(dep).add(dst);
+                inDegree[dst]++;
+            }
+            sb.append(solution(Integer.parseInt(bf.readLine()))).append("\n");
+        }
+        System.out.print(sb);
+    }
+}

--- a/남지현/graph/TheShortestPath1504.java
+++ b/남지현/graph/TheShortestPath1504.java
@@ -1,0 +1,92 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 1504 - 특정한 최단 경로 (골드4)
+
+class Main {
+
+    static Map<Integer, List<int[]>> graph;
+    static int[] dist;
+    static int N;
+
+    static final int MAX = 200_000_001;
+    
+    static class Edge implements Comparable<Edge>{
+        int dest;
+        int value;
+
+        Edge(int dest, int value) {
+            this.dest = dest;
+            this.value = value;
+        }
+
+        public int compareTo(Edge e) {
+            return this.value-e.value;
+        }
+    }
+
+    private static void dijkstra(int departure) {
+        boolean[] visited = new boolean[N+1];
+        dist = new int[N+1];
+        Arrays.fill(dist, MAX);
+        PriorityQueue<Edge> pq = new PriorityQueue<>();
+        pq.add(new Edge(departure, 0));
+        dist[departure]=0;
+        while (!pq.isEmpty()) {
+            Edge now = pq.poll();
+            if (visited[now.dest]) continue;
+            visited[now.dest] = true;
+            for (int[] next: graph.get(now.dest)) {
+                if (dist[next[0]] > dist[now.dest]+next[1]) {
+                    dist[next[0]] = dist[now.dest]+next[1];
+                    pq.add(new Edge(next[0], dist[next[0]]));
+                }
+            }
+        }
+    }
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+        N = Integer.parseInt(st.nextToken());
+        int E = Integer.parseInt(st.nextToken());
+        graph = new HashMap<>();
+        for (int dep=1; dep<=N; dep++) {
+            graph.put(dep, new ArrayList<>());
+        }
+        for (int i=0; i<E; i++) {
+            st = new StringTokenizer(bf.readLine());
+            int x = Integer.parseInt(st.nextToken());
+            int y = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            graph.get(x).add(new int[]{y, v});
+            graph.get(y).add(new int[]{x, v});
+        }
+        st = new StringTokenizer(bf.readLine());
+        int v1 = Integer.parseInt(st.nextToken());
+        int v2 = Integer.parseInt(st.nextToken());
+        
+        dijkstra(v1);
+        int v1ToV2 = dist[v2];
+        
+        dijkstra(1);
+        int dstToV1 = dist[v1];
+        int dstToV2 = dist[v2];
+
+        dijkstra(N);
+        int v1ToN = dist[v1];
+        int v2ToN = dist[v2];
+        
+        int answer = MAX * 3;
+        if (v1ToV2 != MAX && dstToV1 != MAX && v2ToN != MAX) {
+            answer = Math.min(answer, dstToV1 + v1ToV2 + v2ToN);
+        }
+        if (v1ToV2 != MAX && dstToV2 != MAX && v1ToN != MAX) {
+            answer = Math.min(answer, dstToV2 + v1ToV2 + v1ToN);
+        }
+        if (answer == MAX*3) {
+            answer = -1;
+        }
+        System.out.println(answer);
+    }
+}

--- a/남지현/tree/TreeOrderGame.java
+++ b/남지현/tree/TreeOrderGame.java
@@ -1,0 +1,66 @@
+import java.util.*;
+
+// 프로그래머스 - 길 찾기 게임 (Lv 3)
+
+class Solution {
+    int[][] answer;
+    int idx;
+    
+    public int[][] solution(int[][] nodeinfo) {
+        answer = new int[2][nodeinfo.length];
+        List<Node> nodes = new ArrayList<>();
+        for (int i=0; i<nodeinfo.length; i++) {
+            nodes.add(new Node(i+1, nodeinfo[i][0], nodeinfo[i][1]));
+        }
+        Collections.sort(nodes);
+        Node root = nodes.get(0);
+        for (int i=1; i<nodes.size(); i++) {
+            makeTree(root, nodes.get(i));
+        }
+        idx=0;
+        preOrder(root);
+        idx=0;
+        postOrder(root);
+        return answer;
+    }
+    
+    private void makeTree(Node parent, Node child) {
+        if (parent.x > child.x) {
+            if (parent.left == null) parent.left = child;
+            else makeTree(parent.left, child);
+        } else {
+            if (parent.right == null) parent.right = child;
+            else makeTree(parent.right, child);
+        }
+    }
+    
+    private void preOrder(Node node) {
+        answer[0][idx++] = node.num;
+        if (node.left != null) preOrder(node.left);
+        if (node.right != null) preOrder(node.right);
+    }
+    
+    private void postOrder(Node node) {
+        if (node.left != null) postOrder(node.left);
+        if (node.right != null) postOrder(node.right);
+        answer[1][idx++] = node.num;
+    }
+    
+    static class Node implements Comparable<Node> {
+        int num;
+        int x;
+        int y;
+        Node left;
+        Node right;
+        
+        Node(int num, int x, int y) {
+            this.num = num;
+            this.x = x;
+            this.y = y;
+        }
+        
+        public int compareTo(Node node) {
+            return this.y==node.y? this.x-node.x: node.y-this.y;
+        }
+    }
+}


### PR DESCRIPTION
# 주제 or 주차
1주차 7월 22일

## 🔥어려웠던 문제
이번에도 미안합니다...ㅎ 난이도 조절 실패
* A와 B 2
저는 그리디인 줄 알고 가져왔습니다... 단순히 필요한 연산 횟수만큼 둘 중 합리적인 연산을 반복해서 주어진 문자열과 같은지 비교하는 방식으로 접근했는데 두 번째 연산이 B를 맨 끝에 추가한 후 뒤집는 바람에 적용이 힘들었습니다. 현재 상황에서 가능한 역연산을 해가며 탐색하는 것이 포인트였던 것 같아요. 실제로 문자열을 먼저 뒤집은 후 B를 맨 끝에 추가하는 연산이 조건으로 주어진 [A와 B(12904)](https://www.acmicpc.net/problem/12904) 문제도 있었는데 얘는 그리디로 분류되어 있더라구요.
결국 풀이를 찾아보긴 했는데, 찾아본 풀이는 substring 연산을 사용했으나 저는 또 시간을 아껴보겠다고 StringBuilder의 deleteCharAt 메서드를 사용했다가 (길이가 0인데 -1 인덱스에 접근했다고) StringIndexOutOfBoundsException 발생해서 실패했습니다. 찾아보니깐 String 클래스의 substring은 부분문자열에 해당하는 새로운 문자열을 반환하는데 deleteCharAt은 동일 StringBuilder객체의 문자를 삭제하는거라 동일 객체를 계속 인자로 넘기다보면 재귀에서 빠져나올 때 인자의 StringBuilder length가 0인 순간이 생긴다는 것을 알 수 있었습니다.
* ACM Craft
문제에서 위상정렬로 풀어야 한다는 사실이 명확하게 드러나는 것 같아 괜찮을 줄 알고 들고 왔습니다. 동시에 건설이 가능하다는 조건을 보고 처음에 BFS를 곁들여서 풀어보려고 했는데 계속 메모리 초과가 발생해서 어려웠습니다. 다음에 탐색할 노드들을 모두 큐에 넣었을 때는 메모리 초과가 발생했는데 진입차수만 업데이트하고 진입차수가 0인 경우에만 큐에 넣었더니 통과했습니다.

## 😎기록하고 싶은 점
* 특정한 최단 경로
가중치 그래프의 최단 경로를 찾는 문제라 접근 방법이 명확했습니다. 다익스트라 로직을 함수로 빼냈는데 쓸데없이 최단 경로를 리턴하게 만들어서 다익스트라 5번 돌렸습니다. 다익스트라는 출발 노드가 고정되어 있을 때 모든 노드까지의 최단 거리를 구할 수 있다는 것을 잘 기억해야겠어요.
* 길 찾기 게임
재귀 함수로 이진 트리를 구성하는 것이 핵심이었던 것 같은데 트리 구성하는 로직을 검색해보았습니다. 제일 어려울 것 같았는데 오히려 백준 문제들보다 괜찮았던 듯.

## ✅ 푼 문제
- [x] 암호코드
- [x] A와 B 2
- [x] 특정한 최단 경로
- [x] ACM Craft
- [x] 길 찾기 게임
