### PR TITLE
[지현] 0902

### DIFF
--- a/남지현/bfs&dfs/SheepAndWolf.java
+++ b/남지현/bfs&dfs/SheepAndWolf.java
@@ -1,0 +1,42 @@
+import java.util.*;
+
+// 프로그래머스 - 양과 늑대
+
+class Solution {
+    
+    Map<Integer, List<Integer>> graph = new HashMap<>();
+    int[] values;
+    int max = 0;
+    
+    public int solution(int[] info, int[][] edges) {
+        values = info;
+        for (int i=0; i<info.length; i++) {
+            graph.put(i, new ArrayList<>());
+        }
+        for (int[] edge: edges) {
+            graph.get(edge[0]).add(edge[1]);
+        }
+        List<Integer> tmp = new ArrayList<>();
+        tmp.add(0);
+        dfs(0, 0, 0, tmp);
+        return max;
+    }
+    
+    private void dfs(int num, int wolf, int sheep, List<Integer> candidates) {
+        if (values[num] == 0) { 
+            sheep++; 
+        } else { 
+            wolf++; 
+        }
+        max = Math.max(max, sheep);
+        if (sheep <= wolf) { return; }
+        List<Integer> tmp = new ArrayList<>(candidates);
+        if (! graph.get(num).isEmpty()) {
+            tmp.addAll(graph.get(num));
+        }
+        tmp.remove(Integer.valueOf(num));
+        for (int next: tmp) {
+            dfs(next, wolf, sheep, tmp);
+        }
+    }
+}

--- a/남지현/bruteForce/PartitionSum1806.java
+++ b/남지현/bruteForce/PartitionSum1806.java
@@ -1,0 +1,38 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 1806번 - 부분합
+
+class Main {
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int S = Integer.parseInt(st.nextToken());
+        int[] sum = new int[N+1];
+        int answer = 0; int dist = 100_001;
+        int left = 1; int right = 1;
+        st = new StringTokenizer(bf.readLine());
+        for (int i=1; i<=N; i++) {
+            sum[i] = sum[i-1] + Integer.parseInt(st.nextToken());
+            if (sum[i]>=S && answer==0) {
+                right = i;
+                answer = sum[i];
+            }
+        }
+        while (right<=N) {
+            // 합이 S를 넘기면서 최대한 right와의 거리를 좁히도록 left를 이동시킨다.
+            while (left<right && sum[right]-sum[left]>=S) left++;
+            // 거리가 기존 거리보다 짧으면 업데이트한다.
+            if (dist > right-left+1) {
+                dist = right-left+1; 
+                answer = sum[right]-sum[--left];
+            }
+            right++;
+        }
+        // 현재까지 계산된 값이 S를 넘기지 못하면 0을 출력한다.
+        if (answer < S) dist = 0;
+        System.out.println(dist);
+    }
+}

--- a/남지현/dp/LIB11054.java
+++ b/남지현/dp/LIB11054.java
@@ -1,0 +1,36 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 11054번 - 가장 긴 바이토닉 부분 수열
+
+class Main {
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(bf.readLine());
+        int[] arr = new int[N];
+        int[] increasing = new int[N];
+        int[] decreasing = new int[N];
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+        int max = 0;
+        for (int i=0; i<N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+            for (int j=0; j<i; j++) {
+                if (arr[i]>arr[j] && increasing[i]<increasing[j]) {
+                    increasing[i] = increasing[j];
+                }
+            }
+            increasing[i]++;
+        }
+        for (int i=N-1; i>=0; i--) {
+            for (int j=N-1; j>i; j--) {
+                if (arr[i]>arr[j] && decreasing[i]<decreasing[j]) {
+                    decreasing[i] = decreasing[j];
+                }
+            }
+            decreasing[i]++;
+            max = Math.max(max, increasing[i]+decreasing[i]-1);
+        }
+        System.out.println(max);
+    }
+}

--- a/남지현/stack/ParenthesesValue2504.java
+++ b/남지현/stack/ParenthesesValue2504.java
@@ -1,0 +1,65 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 2504번 - 괄호의 값
+
+class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        String str = bf.readLine();
+        int len = str.length();
+        ArrayDeque<int[]> stack = new ArrayDeque<>();
+        int[] values = new int[31];
+        int answer = 0;
+        for(int i=0; i<len; i++) {
+            char c = str.charAt(i);
+            if (c == '(' || c == '[') {
+                stack.addLast(new int[]{i, c});
+            } else if (c == ')') {
+                if (stack.isEmpty() || stack.peekLast()[1]!='(') {
+                    System.out.println(answer);
+                    return;
+                }
+                int start = stack.pollLast()[0];
+                int sum = 0;
+                if (start+1 == i) {
+                    sum = 1;
+                } else {
+                    for (int j=start; j<i; j++) {
+                        if (values[j] != 0) {
+                            sum += values[j];
+                            values[j] = 0;
+                        }
+                    }
+                }
+                values[i] = sum*2;
+            } else if (c == ']') {
+                if (stack.isEmpty() || stack.peekLast()[1]!='[') {
+                    System.out.println(answer);
+                    return;
+                }
+                int start = stack.pollLast()[0];
+                int sum = 0;
+                if (start+1 == i) {
+                    sum = 1;
+                } else {
+                    for (int j=start; j<i; j++) {
+                        if (values[j] != 0) {
+                            sum += values[j];
+                            values[j] = 0;
+                        }
+                    }
+                }
+                values[i] = sum*3;
+            }
+        }
+        if (stack.isEmpty()) {
+            answer = 0;
+        } else {
+            for (int i=1; i<len; i++) {
+                answer += values[i];
+            }
+        }
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
# 주제 or 주차
9월 2일

## 🔥어려웠던 문제
* 양과 늑대: 처음에 양방향 그래프로 만들고 dfs를 돌렸더니 stackoverflow가 발생해서 시간이 많이 걸렸습니다. 그래프 연결을 양방향으로 만들어서 무한으로 중복 탐색을 하게 되어 그랬던 것 같습니다. 단방향으로 연결을 하되, 부모 노드까지 고려해서 다음 이동 가능한 정점을 리스트로 만들어서 재귀 호출시 같이 넘기면서 풀었더니 해결되었습니다. 비트마스킹을 사용하면 더 빠르게 해결 가능하다고 해서 좀 더 고민해보겠습니다.

## 😎기록하고 싶은 점
* 부분합: 문제 이름에서부터 누적합을 써야 하지 않을까 하는 느낌이 와서 쉽게 접근할 수 있었습니다. 
* 괄호의 값: 스택을 사용해 괄호의 짝을 맞추고, 부분문자열의 idx에 맞춰 배열에 값을 저장해서 더하는 방식으로 해결했습니다. 올바른 괄호열을 찾아야 한다는 점에서 스택 풀이를 금방 떠올릴 수 있었어요.
* 가장 긴 바이토닉 부분 수열: 예전에 가장 긴 증가하는 부분수열 문제를 이중 for문 dp를 사용해서 풀어본 적이 있었는데 방법을 살짝 응용하면 쉽게 해결 가능한 문제였습니다.

## ✅ 푼 문제
- [x] 부분합
- [x] 괄호의 값
- [x] 가장 긴 바이토닉 부분 수열
- [x] 양과 늑대
