### PR TITLE
[지현] 0930

### DIFF
--- a/남지현/bfs&dfs/KakaoBadUser.java
+++ b/남지현/bfs&dfs/KakaoBadUser.java
@@ -1,0 +1,35 @@
+import java.util.*;
+import java.util.regex.*;
+
+class Solution {   
+    Pattern[] patterns;
+    String[] ids;
+    Set<Integer> answers;
+    int N;
+    
+    public int solution(String[] user_id, String[] banned_id) {
+        N = banned_id.length;
+        patterns = new Pattern[N];
+        ids = user_id;
+        answers = new HashSet<>();
+        for (int i=0; i<N; i++) {
+            patterns[i] = Pattern.compile(banned_id[i].replaceAll("\\*", "\\."));
+        }
+        dfs(0, 0);
+        return answers.size();
+    }
+    
+    private void dfs(int depth, int used) {
+        if (depth == N) {
+            answers.add(used);
+            return;
+        }
+        for (int i=0; i<ids.length; i++) {
+            int next = used;
+            if (patterns[depth].matcher(ids[i]).matches() && (next&1<<i)==0) {
+                next |= 1<<i;
+                dfs(depth+1, next);
+            }
+        }
+    }
+}

--- a/남지현/bfs&dfs/SnakeAndLadderGame16928.java
+++ b/남지현/bfs&dfs/SnakeAndLadderGame16928.java
@@ -1,0 +1,41 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 16928번 - 뱀과 사다리 게임
+
+class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        Map<Integer, Integer> jump = new HashMap<>();
+        for (int i=0; i<N+M; i++) {
+            st = new StringTokenizer(bf.readLine());
+            jump.put(Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken()));
+        }
+        ArrayDeque<int[]> queue = new ArrayDeque<>();
+        boolean[] visited = new boolean[101];
+        int answer = 101;
+        queue.addLast(new int[]{1, 0});
+        while (!queue.isEmpty()) {
+            int[] now = queue.pollFirst();
+            int idx = now[0];
+            int count = now[1];
+            if (idx==100) {
+                answer = Math.min(answer, count);
+                break;
+            }
+            if (visited[idx]) continue;
+            visited[idx] = true;
+            if (jump.containsKey(idx)) {
+                idx = jump.get(idx);
+            } 
+            for (int i=1; i<=6; i++) {
+                if (idx+i<101)
+                    queue.addLast(new int[]{idx+i, count+1});
+            }
+        }
+        System.out.println(answer);
+    }
+}

--- a/남지현/bruteForce/Minecraft18111.java
+++ b/남지현/bruteForce/Minecraft18111.java
@@ -1,0 +1,123 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 18111번 - 마인크래프트
+
+class Main {
+
+    static final int MAX = 64_000_001;
+
+    private static void faster() throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int B = Integer.parseInt(st.nextToken());
+        int[] counts = new int[257];
+        int min = MAX;
+        int max = 0;
+        for (int i=0; i<N; i++) {
+            st = new StringTokenizer(bf.readLine());
+            for (int j=0; j<M; j++) {
+                int height = Integer.parseInt(st.nextToken());
+                counts[height]++;
+                min = Math.min(min, height);
+                max = Math.max(max, height);
+            }
+        }
+        int answerTime = 2*MAX;
+        int answerHeight = 0;
+        for (int num = min; num <= max; num++) {
+            int remain = B;
+            int time = 0;
+            boolean success = true;
+            for (int h=256; h>=0; h--) {
+                if (counts[h]==0) continue;
+                if (h >= num) { // 블록 제거하여 저장
+                    time += 2*(h-num)*counts[h];
+                    remain += (h-num)*counts[h];
+                } else if (remain >= (num-h)*counts[h]){ // 채워야 하는 블록 충분한 경우
+                    time += (num-h)*counts[h];
+                    remain -= (num-h)*counts[h];
+                } else {
+                    success = false;
+                    break;
+                }
+            }
+            if (success) {
+                if (answerTime > time) {
+                    answerTime = time;
+                    answerHeight = num;
+                } else if (answerTime == time) {
+                    if (answerHeight < num) {
+                        answerHeight = num;
+                    }
+                }
+            }
+        }
+        System.out.printf("%d %d\n", answerTime, answerHeight);
+    }
+
+    private static void trial1() throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(bf.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int B = Integer.parseInt(st.nextToken());
+        int len = N*M;
+        int[] board = new int[len];
+        int min = MAX;
+        int max = 0;
+        for (int i=0; i<N; i++) {
+            st = new StringTokenizer(bf.readLine());
+            for (int j=0; j<M; j++) {
+                int idx = i*M+j;
+                board[idx] = Integer.parseInt(st.nextToken());
+                min = Math.min(min, board[idx]);
+                max = Math.max(max, board[idx]);
+            }
+        }
+        int answerTime = 2*MAX;
+        int answerHeight = 0;
+        for (int num = min; num <= max; num++) {
+            int remain = B;
+            int time = 0;
+            boolean success = true;
+            for (int i=0; i<len; i++) {
+                if (board[i]>num) {
+                    remain += board[i]-num;
+                    time += 2*(board[i]-num);
+                }
+            }
+            for (int i=0; i<len; i++) {
+                if (board[i]<num) {
+                    if (remain >= num-board[i]) {
+                        remain -= num-board[i];
+                        time += num-board[i];
+                    } else {
+                        success = false;
+                        break;
+                    }
+                }
+            }
+            if (success) {
+                if (answerTime > time) {
+                    answerTime = time;
+                    answerHeight = num;
+                } else if (answerTime == time) {
+                    if (answerHeight < num) {
+                        answerHeight = num;
+                    }
+                }
+            }
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append(answerTime).append(" ").append(answerHeight);
+        System.out.println(sb);
+    }
+    
+    public static void main(String[] args) throws Exception {
+        trial1();
+        // faster();
+    }
+}

--- a/남지현/dp/DDR2342.java
+++ b/남지현/dp/DDR2342.java
@@ -1,0 +1,51 @@
+import java.io.*;
+
+// 백준 2342번 - Dance Dance Revolution
+
+class Main {
+
+    private static int cost(int before, int after) {
+        if (before==0) return 2;
+        if (before==after) return 1;
+        if (after-before==2 || before-after==2) return 4;
+        return 3;
+    }
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader bf = new BufferedReader(new InputStreamReader(System.in));
+        String[] tokens = bf.readLine().split(" ");
+        int N = tokens.length-1;
+        int[] points = new int[N];
+        for (int i=0; i<N; i++) {
+            points[i] = Integer.parseInt(tokens[i]);
+        }
+        int[][][] memo = new int[points.length][5][5];
+        memo[0][points[0]][0] = 2;
+        memo[0][0][points[0]] = 2;
+        for (int i=1; i<N; i++) {
+            for (int j=0; j<5; j++) {
+                for (int k=0; k<5; k++) {
+                    if (memo[i-1][j][k] == 0) continue;
+                    if (memo[i][j][points[i]] == 0) {
+                        memo[i][j][points[i]] = memo[i-1][j][k]+cost(k, points[i]);
+                    } else {
+                        memo[i][j][points[i]] = Math.min(memo[i][j][points[i]], memo[i-1][j][k]+cost(k, points[i]));
+                    }
+                    if (memo[i][points[i]][k] == 0) {
+                        memo[i][points[i]][k] = memo[i-1][j][k]+cost(j, points[i]);
+                    } else {
+                        memo[i][points[i]][k] = Math.min(memo[i][points[i]][k], memo[i-1][j][k]+cost(j, points[i]));
+                    }
+                }
+            }
+        }
+        int answer = 400_001;
+        for (int i=0; i<5; i++) {
+            if (memo[N-1][points[N-1]][i]>0)
+                answer = Math.min(answer, memo[N-1][points[N-1]][i]);
+            if (memo[N-1][i][points[N-1]]>0)
+                answer = Math.min(answer, memo[N-1][i][points[N-1]]);
+        }
+        System.out.println(answer);
+    }
+}

--- a/남지현/simulation/DrawStars2448.java
+++ b/남지현/simulation/DrawStars2448.java
@@ -1,0 +1,41 @@
+import java.util.*;
+
+// 백준 2448 - 별 찍기-11
+class Main {
+
+    static int N;
+    static boolean[][] board;
+
+    private static void draw(int row, int col, int size) {
+        if (size==3) {
+            board[row-2][col] = true;
+            board[row-1][col-1] = true;
+            board[row-1][col+1] = true;
+            for (int i=col-2; i<=col+2; i++) {
+                board[row][i] = true;
+            }
+            return;
+        }
+        draw(row-size/2, col, size/2);
+        draw(row, col-size/2, size/2);
+        draw(row, col+size/2, size/2);
+    }
+
+    
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        N = sc.nextInt();
+        board = new boolean[N+1][2*N];
+        draw(N, N, N);
+        StringBuilder sb = new StringBuilder();
+        for (int i=1; i<=N; i++) {
+            for (int j=1; j<2*N; j++) {
+                if (board[i][j]) sb.append('*');
+                else sb.append(" ");
+            }
+            sb.append("\n");
+        }
+        System.out.print(sb);
+        sc.close();
+    }
+}


### PR DESCRIPTION
# 주제 or 주차
0930

## 🔥어려웠던 문제
* 뱀과 사다리 게임: 처음에 주사위를 던져서 이동하는 경우와 뱀, 사다리를 통해 이동하는 경우에 대해 모두 탐색하려고 했습니다. 100번 칸에 도달하면 탐색을 멈추는 BFS의 장점을 취하기 위해 가지치기할 때 우선순위를 매겨볼까 생각도 해봤는데 주사위, 뱀, 사다리 각각에 대한 이득에 대해 명확한 순위가 매겨지지 않는 것이 고민되는 지점이었습니다. 별도의 우선순위를 두지 않기 위해서 시간이 계산되는 경우만 큐에 넣어서 탐색하도록 해보았습니다. 뱀이나 사다리를 통해 이동하는 경우에는 시간이 추가되지 않기 때문에 인덱스만 계산해서 이동 후 주사위를 던지는 경우에 따라 큐에 넣어 탐색해나갔습니다. 방문한 칸을 마킹하는 것도 상당히 헷갈리는 부분 중 하나였습니다. 뱀을 타는 경로나 사다리를 타는 경로는 여러 번 지날 수도 있어야 해서 마킹을 하지 않는 부분이 어려웠습니다.
* DDR: 탐색을 하자니 $$O(2^N)$$인데 길이가 100,000이라서 안될 것 같았고, 그리디로도 해결이 안될 것 같아서 DP문제구나 싶었습니다. 눌러야 하는 위치를 순서대로 탐색해야 하고, 왼발과 오른발 위치 순서쌍에 대한 cost를 저장해야 하기 때문에 3차원 배열이 사용되는 것까지는 알 수 있었습니다. 점화식도 대략적으로는 세웠는데,  초기화 여부에 따른 분기 처리가 헷갈려서 정밀하게 처리하지 못했고 체감 난이도가 더 올라갔던 것 같습니다. Top-down 풀이도 찾아보았는데 탐색을 사용하되 메모이제이션을 활용하는거라 더 직관적이었어요. 다만 제가 낯설어서 혼자는 못 세울 것 같아요ㅋㅋㅋ Top-down DP 풀이도 익숙하게 만들어야겠어요.

## 😎기록하고 싶은 점
* 마인드크래프트: 처음엔 N*M 크기의 배열을 (최대높이-최소높이+1)번 돌면서 일일이 계산했습니다. 높이의 분포를 조사해서 동일한 높이에 대해서는 시간을 한 번에 계산하니 시간이 많이 단축되더라구요. 두 가지 풀이 모두 입력해두었습니다.
* 불량 사용자: 단순히 해시맵과 정규표현식을 사용하는 문제라고 생각해서 접근했는데 경우의 수 계산으로 떨어지지 않는 것을 보고 탐색 문제라는 것을 인지했습니다. 문자열로 된 id들의 순서를 고려하지 않은 조합의 가짓수를 세는 것이 가장 고민되는 점이었는데 방문 id 마킹을 배열대신 비트마스킹을 사용하니 간단하게 해결되었습니다.

## ✅ 푼 문제
- [x] 마인크래프트
- [x] 뱀과 사다리 게임
- [x] 별 찍기 - 11
- [x] Dance Dance Revolution
- [x] 불량 사용자
