### PR TITLE
[주은] 1230

### DIFF
--- a/이주은/DFS-BFS/출퇴근길.java
+++ b/이주은/DFS-BFS/출퇴근길.java
@@ -1,0 +1,68 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        List<List<Integer>> adj = new ArrayList<>();
+        List<List<Integer>> adjR = new ArrayList<>();
+
+        for(int i=0; i<=N; i++) {
+            adj.add(new ArrayList<>());
+            adjR.add(new ArrayList<>());
+        }
+        
+        for(int i=0; i<M; i++) {
+            st = new StringTokenizer(br.readLine());
+
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            adj.get(from).add(to);
+            adjR.get(to).add(from);
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int S = Integer.parseInt(st.nextToken());
+        int T = Integer.parseInt(st.nextToken());
+
+        //어떤 노드가 S로부터 도달 가능하고 T로 도달 가능하면 S->T의 경로가 성립한다.
+        boolean[] fromS = new boolean[N+1];
+        fromS[T] = true; //목적지 정점 방문 시 더이상 진행 X
+        dfs(S, adj, fromS);
+
+        boolean[] toT = new boolean[N+1];
+        dfs(T, adjR, toT);
+
+
+        boolean[] fromT = new boolean[N+1];
+        fromT[S] = true;
+        dfs(T, adj, fromT);
+        
+        boolean[] toS = new boolean[N+1];
+        dfs(S, adjR, toS);
+
+        int answer = 0;
+        for(int i=1; i<=N; i++) {
+            if(fromS[i] && toS[i] && fromT[i] && toT[i])
+                answer ++;
+        }
+
+        System.out.println(answer-2);
+    }
+
+    private static void dfs(int now, List<List<Integer>> adj, boolean[] visited) {
+        visited[now] = true;
+
+        for(int next : adj.get(now)) {
+            if(!visited[next])
+                dfs(next, adj, visited);
+        }
+    }
+}

--- a/이주은/DP/점프.java
+++ b/이주은/DP/점프.java
@@ -1,0 +1,41 @@
+import java.util.*;
+import java.io.*;
+
+class Main {
+    static int N;
+    static int[][] map;
+    static long[][] cnt;
+    
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        map = new int[N][N];
+        cnt = new long[N][N];
+
+        cnt[0][0] = 1;
+        
+        for(int i=0; i<N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j=0; j<N; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+
+                if(cnt[i][j] == 0 || map[i][j] == 0)
+                    continue;
+
+                int next = i + map[i][j];
+                if(next < N) {
+                    cnt[next][j] += cnt[i][j];
+                }
+
+                next = j + map[i][j];
+                if(next < N) {
+                    cnt[i][next] += cnt[i][j];               
+                }
+            } 
+        }
+
+        System.out.println(cnt[N-1][N-1]);
+    }
+}

--- a/이주은/Graph/업무처리.java
+++ b/이주은/Graph/업무처리.java
@@ -1,0 +1,94 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    static int H, K, R;
+
+    private static final class Node {
+        Deque<Integer> left;
+        Deque<Integer> right;
+
+        Node() {
+            this.left = new ArrayDeque<>();
+            this.right = new ArrayDeque<>();
+        }
+    }
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        H = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+        R = Integer.parseInt(st.nextToken());
+
+        List<Node> tree = new ArrayList<>();
+
+        int N = 1 << (H-1)+1;
+        for(int i=0; i<=N; i++) {
+            tree.add(new Node());
+        }
+
+        for(int i=(1<<H); i<(1<<H+1); i++) {
+            Node parent = tree.get(i/2);
+            Queue queue;
+            
+            //왼쪽 자식 노드일 경우
+            if(i%2 == 0) {
+                queue = parent.left;
+            }
+            //오른쪽 자식 노드일 경우
+            else {
+                queue = parent.right;
+            }
+            
+            st = new StringTokenizer(br.readLine());
+            for(int j=0; j<K; j++) {
+                int task = Integer.parseInt(st.nextToken());
+                queue.add(task);
+            }
+        }
+
+        for(int day=2; day<=R; day++) {
+            for(int i=1; i<=N; i++) {
+                Deque<Integer> parent;
+                Deque<Integer> child;
+
+                if(day%2 == 0) {
+                    parent = tree.get(i/2).right;
+                    child = tree.get(i).right;
+                }
+                else {
+                    parent = tree.get(i/2).left;
+                    child = tree.get(i).left;
+                }
+
+                if(i%2 == 0) {
+                   parent = tree.get(i/2).left;
+                }
+                    
+                else {
+                   parent = tree.get(i/2).right;
+                }
+
+                if(!child.isEmpty()) {
+                    parent.add(child.poll());
+                }
+            }
+        }
+
+        int answer = 0;
+        
+        Deque<Integer> done = tree.get(0).left;
+        while(!done.isEmpty()) {
+            answer += done.poll();
+        }
+
+        done = tree.get(0).right;
+        while(!done.isEmpty()) {
+            answer += done.poll();
+        }
+
+        System.out.println(answer);
+    }
+}

--- a/이주은/Greedy/호안에수류탄이야!!15889.java
+++ b/이주은/Greedy/호안에수류탄이야!!15889.java
@@ -1,0 +1,39 @@
+import java.util.*;
+import java.io.*;
+
+class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int N = Integer.parseInt(br.readLine());
+
+        if(N == 1) {
+            System.out.println("권병장님, 중대장님이 찾으십니다");
+            return;
+        }
+        
+        int[] pos = new int[N];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<N; i++) {
+            pos[i] = Integer.parseInt(st.nextToken());
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int range = 0;
+        
+        for(int i=1; i<N; i++) {
+            int pow = Integer.parseInt(st.nextToken());
+
+            range = Math.max(range, pos[i-1] + pow);
+
+            if(range < pos[i]) {
+                System.out.println("엄마 나 전역 늦어질 것 같아");
+                return;
+            }
+        }
+        
+        System.out.println("권병장님, 중대장님이 찾으십니다");
+    }
+}


### PR DESCRIPTION
# 1230

## 🔥 어려웠던 문제
### 업무처리
- 포화이진트리를 구현해야 했는데, 필요한 노드의 수를 계산하는 것이 어려웠습니다.
- 단말 노드와 루트 노드들은 구현이 달라져야 했는데 어떻게 구현할 수 있을까 고민을 했습니다.
- 해결
  - 이진트리이기 때문에 배열을 이용하여 이진트리를 구성하였습니다.
  - 단말 노드는 과감히 제거하고, day2부터 시작하여 단말 노드의 구분을 없앨 수 있었습니다.
  - 루트 노드 또한 1/2가 0이기 때문에 0번째 노드를 통해 완료된 업무를 체크해줌으로써 루트 노드의 구분도 없앨 수 있었습니다.

### 출퇴근길
- [해설강의](https://www.youtube.com/watch?v=PAihI2CGr-M) 봤습니다.
- 역인접리스트가 왜 필요한지 잘 몰랐는데 이제 알았네요 ㅎㅎ

## 😎 기록하고 싶은 점
- 이진 트리는 배열로 나타낼 수 있습니다.
  - `i/2`를 통해 부모노드에 접근할 수 있습니다.
  - `i*2`를 통해 왼쪽 자식 노드에 접근할 수 있습니다.
  - `i*2 + 1`을 통해 오른쪽 자식 노드에 접근할 수 있습니다.
  - 루트노드는 1번 인덱스에 배정되는데... 0번째 인덱스에 배정될 경우, 양쪽 자식 노드가 부모노드에 같은 수식으로 계산된 인덱스에 접근할 수 없어서 그렇더라구용 ㅎㅎ

- 어떤 노드가 S로부터 도달 가능하고 T로 도달 가능하면 S->T의 경로가 성립한다.
- 어떤 노드로부터 도달 가능한 노드들은 인접리스트를 탐색해서 알 수 있다.
- 어떤 노드로 도달 가능한 노드들은 역 인접리스트를 탐색해서 알 수 있다.

## ✅ 푼 문제
- [x] [Softeer 출퇴근길](https://softeer.ai/practice/6248)
- [x] [Softeer 업무처리](https://softeer.ai/practice/6251)
- [x] [BOJ 1809번 점프](https://www.acmicpc.net/problem/1890)
- [x] [BOJ 15889번 호 안에 수류탄이야!!](https://www.acmicpc.net/problem/15889)
