### PR TITLE
[지현] 1230

### DIFF
--- a/남지현/bfs&dfs/SofteerIntersectNodes.java
+++ b/남지현/bfs&dfs/SofteerIntersectNodes.java
@@ -1,0 +1,73 @@
+import java.io.*;
+import java.util.*;
+
+// Softeer - [HSAT 6회 정기 코딩 인증평가 기출] 출퇴근길
+public class Main {
+
+    static int n, S, T;
+    static boolean[] visited;
+    static Map<Integer, List<Integer>> originalGraph, reverseGraph;
+
+    private static int solution() {
+        Set<Integer> ST = getReachableNodes(S, T);
+        Set<Integer> TS = getReachableNodes(T, S);
+        
+        ST.retainAll(TS);
+        int answer = ST.size();
+        if (ST.contains(S)) {
+            answer--;
+        }
+        if (ST.contains(T)) {
+            answer--;
+        }
+        return answer;
+    }
+
+    private static Set<Integer> getReachableNodes(int start, int end) {
+        Set<Integer> fromStart = new HashSet<>();
+        Set<Integer> fromEnd = new HashSet<>();
+        visited = new boolean[n+1];
+        dfs(start, end, originalGraph, fromStart);
+        visited = new boolean[n+1];
+        dfs(end, -1, reverseGraph, fromEnd);
+        fromStart.retainAll(fromEnd);
+        return fromStart;
+    }
+
+    private static void dfs(int node, int end, Map<Integer, List<Integer>> graph, Set<Integer> nodes) {
+        if (end!=-1 && node == end) {
+            return;
+        }
+        for (int next: graph.get(node)) {
+            if (!visited[next]) {
+                visited[next] = true;
+                nodes.add(next);
+                dfs(next, end, graph, nodes);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        originalGraph = new HashMap<>();
+        reverseGraph = new HashMap<>();
+        for (int i=1; i<=n; i++) {
+            originalGraph.put(i, new ArrayList<>());
+            reverseGraph.put(i, new ArrayList<>());
+        }
+        for (int i=0; i<m; i++) {
+            st = new StringTokenizer(br.readLine());
+            Integer fromNode = Integer.valueOf(st.nextToken());
+            Integer toNode = Integer.valueOf(st.nextToken());
+            originalGraph.get(fromNode).add(toNode);
+            reverseGraph.get(toNode).add(fromNode);
+        }
+        st = new StringTokenizer(br.readLine());
+        S = Integer.parseInt(st.nextToken());
+        T = Integer.parseInt(st.nextToken());
+        System.out.println(solution());
+    }
+}

--- a/남지현/dp/Jump1890.java
+++ b/남지현/dp/Jump1890.java
@@ -1,0 +1,29 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 1890번 점프
+class Main {
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        StringTokenizer st;
+        long[][] count = new long[N][N];
+        count[0][0] = 1l;
+        for (int i=0; i<N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j=0; j<N; j++) {
+                int jump = Integer.parseInt(st.nextToken());
+                if (count[i][j] == 0) continue;
+                if (i==N-1 && j==N-1) break;
+                if (i+jump < N) {
+                    count[i+jump][j] += count[i][j];
+                }
+                if (j+jump < N) {
+                    count[i][j+jump] += count[i][j];
+                }
+            }
+        }
+        System.out.println(count[N-1][N-1]);
+    }
+}

--- a/남지현/greedy/Grenade15889.java
+++ b/남지현/greedy/Grenade15889.java
@@ -21,15 +21,14 @@ class Main {
         }
         st = new StringTokenizer(br.readLine());
         boolean result = false;
-        int left = 0, right = 0;
+        int end = 0;
         for (int i=0; i<N-1; i++) {
             int dist = Integer.parseInt(st.nextToken());
-            if (point[i] > right) {
+            if (point[i] > end) {
                 break;
-            } else {
-                right = Math.max(right, point[i]+dist);
-            }
-            if (right >= point[N-1]) {
+            } 
+            end = Math.max(end, point[i]+dist);
+            if (end >= point[N-1]) {
                 result = true;
                 break;
             }

--- a/남지현/greedy/Grenade15889.java
+++ b/남지현/greedy/Grenade15889.java
@@ -1,0 +1,98 @@
+import java.util.*;
+import java.io.*;
+
+// 백준 15889번 - 호 안에 수류탄이야!!
+class Main {
+
+    static final String enable = "권병장님, 중대장님이 찾으십니다";
+    static final String unable = "엄마 나 전역 늦어질 것 같아";
+
+    private static void sweepSolution() throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] point = new int[N];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i=0; i<N; i++) {
+            point[i] = Integer.parseInt(st.nextToken());
+        }
+        if (N==1) {
+            System.out.println(enable);
+            return;
+        }
+        st = new StringTokenizer(br.readLine());
+        boolean result = false;
+        int left = 0, right = 0;
+        for (int i=0; i<N-1; i++) {
+            int dist = Integer.parseInt(st.nextToken());
+            if (point[i] > right) {
+                break;
+            } else {
+                right = Math.max(right, point[i]+dist);
+            }
+            if (right >= point[N-1]) {
+                result = true;
+                break;
+            }
+        }
+        System.out.println(result? enable : unable);
+    }
+
+    private static void pqSolution() throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        int[] point = new int[N];
+        int[] dist = new int[N-1];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i=0; i<N; i++) {
+            point[i] = Integer.parseInt(st.nextToken());
+        }
+        if (N==1) {
+            System.out.println(enable);
+            return;
+        }
+        st = new StringTokenizer(br.readLine());
+        for (int i=0; i<N-1; i++) {
+            dist[i] = Integer.parseInt(st.nextToken());
+        }
+        boolean[] visited = new boolean[N];
+        PriorityQueue<State> pq = new PriorityQueue<>();
+        pq.add(new State(0, point[0]));
+        while (!pq.isEmpty()) {
+            State now = pq.poll();
+            if (now.idx == N-1) {
+                break;
+            }
+            int max = now.pt + dist[now.idx];
+            for (int i=now.idx; i<N; i++) {
+                if (point[i] <= max) {
+                    if (!visited[i]) {
+                        pq.add(new State(i, point[i]));
+                        visited[i] = true;
+                    }
+                } else {
+                    break;
+                }
+            }
+        }
+        System.out.println(visited[N-1]? enable : unable);
+    }
+
+
+    private static class State implements Comparable<State> {
+        int idx;
+        int pt;
+
+        State(int idx, int pt) {
+            this.idx = idx;
+            this.pt = pt;
+        }
+
+        public int compareTo(State state) {
+            return state.pt - this.pt;
+        }
+    }
+    
+    public static void main(String[] args) throws Exception {
+        sweepSolution();
+    }
+}

--- a/남지현/tree/SofteerTaskWork.java
+++ b/남지현/tree/SofteerTaskWork.java
@@ -57,26 +57,26 @@ public class Main {
         int L = (int) Math.pow(2, H); // 리프 노드의 개수 : 2^H
         int N = 2*L-1; // 총 노드의 개수 : 2^(H+1)-1
         // parent 노드 연결
-        List<Node> CBT = new ArrayList<>(N);
+        List<Node> FBT = new ArrayList<>(N);
         for (int i=0; i<N; i++) {
-            CBT.add(new Node(i));
+            FBT.add(new Node(i));
             if (i==0) continue;
-            CBT.get(i).parent = CBT.get((i-1)/2);
+            FBT.get(i).parent = FBT.get((i-1)/2);
         }
         // 리프노드 업무 분담
         for (int i=L-1; i<N; i++) {
             st = new StringTokenizer(br.readLine());
             for (int j=0; j<K; j++) {
                 if (j%2==0) 
-                    CBT.get(i).left.addLast(Integer.parseInt(st.nextToken()));
+                    FBT.get(i).left.addLast(Integer.parseInt(st.nextToken()));
                 else 
-                    CBT.get(i).right.addLast(Integer.parseInt(st.nextToken()));
+                    FBT.get(i).right.addLast(Integer.parseInt(st.nextToken()));
             }
         }
         time = 1;
         for (; time<=R; time++) {
             for (int i=0; i<N; i++) {
-                CBT.get(i).work();
+                FBT.get(i).work();
             }
         }
         System.out.println(sum);

--- a/남지현/tree/SofteerTaskWork.java
+++ b/남지현/tree/SofteerTaskWork.java
@@ -1,0 +1,84 @@
+import java.util.*;
+import java.io.*;
+
+// Softeer - [HSAT 5회 정기 코딩 인증평가 기출] 업무 처리
+public class Main {
+
+    static int sum, time;
+
+    private static class Node {
+        int idx;
+        Node parent;
+        ArrayDeque<Integer> left;
+        ArrayDeque<Integer> right;
+
+        Node(int idx) {
+            this. idx = idx;
+            this. parent = null;
+            this.left = new ArrayDeque<>();
+            this.right = new ArrayDeque<>();
+        }
+
+        void work() {
+            int work = -1;
+            if (time%2 == 0) {
+                if (this.right.isEmpty()) return;
+                work = this.right.pollFirst();
+            }
+            else {
+                if (this.left.isEmpty()) return;
+                work = this.left.pollFirst();
+            }
+            
+            if (this.idx == 0) {
+                sum += work;
+            } else {
+                if (this.isLeftChild()) {
+                    this.parent.left.addLast(work);
+                } else {
+                    this.parent.right.addLast(work);
+                }
+            }
+        }
+        
+        private boolean isLeftChild() {
+            if (this.parent == null) return false;
+            return (this.parent.idx+1)*2 != this.idx;
+        }
+    }
+    
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int H = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+        int R = Integer.parseInt(st.nextToken());
+        int L = (int) Math.pow(2, H); // 리프 노드의 개수 : 2^H
+        int N = 2*L-1; // 총 노드의 개수 : 2^(H+1)-1
+        // parent 노드 연결
+        List<Node> CBT = new ArrayList<>(N);
+        for (int i=0; i<N; i++) {
+            CBT.add(new Node(i));
+            if (i==0) continue;
+            CBT.get(i).parent = CBT.get((i-1)/2);
+        }
+        // 리프노드 업무 분담
+        for (int i=L-1; i<N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j=0; j<K; j++) {
+                if (j%2==0) 
+                    CBT.get(i).left.addLast(Integer.parseInt(st.nextToken()));
+                else 
+                    CBT.get(i).right.addLast(Integer.parseInt(st.nextToken()));
+            }
+        }
+        time = 1;
+        for (; time<=R; time++) {
+            for (int i=0; i<N; i++) {
+                CBT.get(i).work();
+            }
+        }
+        System.out.println(sum);
+    }
+}


### PR DESCRIPTION
# 12/30

## 🔥 어려웠던 문제
### 출퇴근길
- DFS로 노드를 탐색하면서 무한루프를 돌지 않게 하기 위해서는 각 노드를 한 번씩만 거치도록 탐색할 수 밖에 없는데, 문제에서는 도착 노드를 제외한 모든 노드를 여러 번 거칠 수 있고 도달 가능한 모든 노드를 모아야 해서 막혔습니다.
- 일단 출발지에서 도착지까지 DFS를 돌리면서 도달할 수 있는 중간 노드를 먼저 모으고, 각 중간 노드에서 도착지까지 도달할 수 있는 노드만 필터링하는 것이 기본적인 풀이인 것 같았습니다. 그러나 노드의 개수만큼 DFS를 돌리는 것은 비효율적이기 때문에 역방향 그래프를 사용하여 도착지에서 도달할 수 있는 모든 노드의 집합에서 처음의 중간 노드 집합과의 교집합을 구하는 것이 핵심이었던 것 같습니다.
- 출발지에서 도착지까지 이동하는 경로 상의 노드를 구하는 것이 아니라 출발지 또는 도착지에서 도달할 수 있는 노드들을 찾아야 하는데, DFS를 돌릴 때 집합에 노드를 추가하는 작업을 visited 배열을 바탕으로 맨 마지막에 실행해서 노드가 누락되는 것이 문제였습니다.
- 역방향 탐색은 도착지에서 도달할 수 있는 노드를 기록하기 위함이기 때문에 탐색을 멈출 노드를 따로 지정하면 안된다는 점도 중요했습니다.
- 출근길 경로에는 T가 들어가면 안되고 퇴근길 경로에는 S가 들어가면 안되기 때문에 둘의 교집합에는 S 또는 T가 들어갈 수 없다는 것도 생각해 볼 만한 지점이었습니다.

## 😎 기록하고 싶은 점
- 호 안에 수류탄이야!! : 처음에는 사거리 내의 전우들에게 전달하는 경우를 모두 우선순위 큐에 넣고 마지막 전우에게 도달하는 경우에 반복문을 빠져나오도록 코드를 작성했는데, 마지막 전우에 도달하지 못할 경우 사거리 내의 모든 전우들을 탐색해야 하기 때문에 성공은 했지만 실행 시간이 상당히 길게 나왔습니다. 스위핑 알고리즘에 대한 설명을 읽고 다시 풀어보았어요.

## ✅ 푼 문제
- [x] 호 안에 수류탄이야!!
- [x] 점프
- [x] 업무처리
- [x] 출퇴근길
