### PR TITLE
[승주] 0127

### DIFF
--- a/김승주/baekjoon/Graph/15681 트리와 쿼리/Main.java
+++ b/김승주/baekjoon/Graph/15681 트리와 쿼리/Main.java
@@ -1,0 +1,74 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int[] numOfNodes;
+    static List<Integer>[] graph;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        int N = Integer.parseInt(st.nextToken());
+        int R = Integer.parseInt(st.nextToken());
+        int Q = Integer.parseInt(st.nextToken());
+        graph = new List[N + 1];
+        numOfNodes = new int[N + 1];
+        
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < N - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int U = Integer.parseInt(st.nextToken());
+            int V = Integer.parseInt(st.nextToken());
+            graph[U].add(V);
+            graph[V].add(U);
+        }
+        
+        Node rootNode = new Node(R);
+        makeTree(rootNode);
+        numOfNodes[R] = countNodes(rootNode);
+        for (int i = 0; i < Q; i++) {
+            sb.append(numOfNodes[Integer.parseInt(br.readLine())]).append("\n");
+        }
+        System.out.print(sb.toString());
+    }
+
+    private static void makeTree(Node subRoot) {
+        for (int childNum : graph[subRoot.num]) {
+            Node childNode = new Node(childNum);
+            subRoot.children.add(childNode);
+            graph[childNum].remove(graph[childNum].indexOf(subRoot.num));
+            makeTree(childNode);
+        }
+    }
+
+    private static int countNodes(Node subRoot) {
+        if (numOfNodes[subRoot.num] > 0) {
+            return numOfNodes[subRoot.num];
+        }
+        if (subRoot.children.isEmpty()) {
+            return 1;
+        }
+
+        int count = 1;
+        for (Node child : subRoot.children) {
+            int num = countNodes(child);
+            numOfNodes[child.num] = num;
+            count += num;
+        }
+        return count;
+    }
+
+    static class Node {
+        int num;
+        List<Node> children;
+
+        Node (int num) {
+            this.num = num;
+            this.children = new ArrayList<>();
+        }
+    }
+}

--- a/김승주/baekjoon/Graph/1939 중량제한/Main.java
+++ b/김승주/baekjoon/Graph/1939 중량제한/Main.java
@@ -8,6 +8,9 @@ class Main {
         int N = Integer.parseInt(st.nextToken());
         int M = Integer.parseInt(st.nextToken());
 
+        int left = 1;
+        int right = 1;
+
         List<Island>[] graph = new List[N + 1];
         for (int i = 1; i <= N; i++) {
             graph[i] = new ArrayList<>();
@@ -21,38 +24,46 @@ class Main {
 
             graph[A].add(new Island(B, C));
             graph[B].add(new Island(A, C));
+            right = Math.max(right, C);
         }
 
         st = new StringTokenizer(br.readLine());
         int start = Integer.parseInt(st.nextToken());
         int end = Integer.parseInt(st.nextToken());
 
-        System.out.println(bfs(graph, N, start, end));
+
+        while (left <= right) { 
+            int mid = (left + right) / 2;
+            if (bfs(graph, N, start, end, mid)) {
+                left = mid + 1;
+            } else {
+                right = mid - 1;
+            }
+        }
+
+        System.out.println(right);
     }
 
-    private static int bfs(List<Island>[] graph, int N, int start, int end) {
-        int maxWeight = 0;
+    private static boolean bfs(List<Island>[] graph, int N, int start, int end, int target) {
+        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
         boolean[] visited = new boolean[N + 1];
-        Queue<Island> q = new LinkedList<>();
-        q.offer(new Island(start, Integer.MAX_VALUE));
-        visited[start] = true;
+        pq.offer(start);
 
-        while (!q.isEmpty()) {
-            Island curr = q.poll();
-            if (curr.num == end) {
-                maxWeight = Math.max(maxWeight, curr.weight);
-                continue;
+        while (!pq.isEmpty()) {
+            int curr = pq.poll();
+            if (curr == end) {
+                return true;
             }
 
-            for (Island neighbor : graph[curr.num]) {
-                if (!visited[neighbor.num]) {
+            for (Island neighbor : graph[curr]) {
+                if (!visited[neighbor.num] && neighbor.weight >= target) {
                     visited[neighbor.num] = true;
-                    q.offer(new Island(neighbor.num, Math.min(curr.weight, neighbor.weight)));
+                    pq.offer(neighbor.num);
                 }
             }
         }
 
-        return maxWeight;
+        return false;
     }
 
     static class Island {

--- a/김승주/baekjoon/Graph/1939 중량제한/Main.java
+++ b/김승주/baekjoon/Graph/1939 중량제한/Main.java
@@ -1,0 +1,67 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        List<Island>[] graph = new List[N + 1];
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 1; i <= M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int A = Integer.parseInt(st.nextToken());
+            int B = Integer.parseInt(st.nextToken());
+            int C = Integer.parseInt(st.nextToken());
+
+            graph[A].add(new Island(B, C));
+            graph[B].add(new Island(A, C));
+        }
+
+        st = new StringTokenizer(br.readLine());
+        int start = Integer.parseInt(st.nextToken());
+        int end = Integer.parseInt(st.nextToken());
+
+        System.out.println(bfs(graph, N, start, end));
+    }
+
+    private static int bfs(List<Island>[] graph, int N, int start, int end) {
+        int maxWeight = 0;
+        boolean[] visited = new boolean[N + 1];
+        Queue<Island> q = new LinkedList<>();
+        q.offer(new Island(start, Integer.MAX_VALUE));
+        visited[start] = true;
+
+        while (!q.isEmpty()) {
+            Island curr = q.poll();
+            if (curr.num == end) {
+                maxWeight = Math.max(maxWeight, curr.weight);
+                continue;
+            }
+
+            for (Island neighbor : graph[curr.num]) {
+                if (!visited[neighbor.num]) {
+                    visited[neighbor.num] = true;
+                    q.offer(new Island(neighbor.num, Math.min(curr.weight, neighbor.weight)));
+                }
+            }
+        }
+
+        return maxWeight;
+    }
+
+    static class Island {
+        int num;
+        int weight;
+
+        Island (int num, int weight) {
+            this.num = num;
+            this.weight = weight;
+        }
+    }
+}

--- a/김승주/baekjoon/Graph/1939 중량제한/Main.java
+++ b/김승주/baekjoon/Graph/1939 중량제한/Main.java
@@ -8,9 +8,7 @@ class Main {
         int N = Integer.parseInt(st.nextToken());
         int M = Integer.parseInt(st.nextToken());
 
-        int left = 1;
-        int right = 1;
-
+        int left = 1, right = 1;
         List<Island>[] graph = new List[N + 1];
         for (int i = 1; i <= N; i++) {
             graph[i] = new ArrayList<>();
@@ -21,18 +19,21 @@ class Main {
             int A = Integer.parseInt(st.nextToken());
             int B = Integer.parseInt(st.nextToken());
             int C = Integer.parseInt(st.nextToken());
-
             graph[A].add(new Island(B, C));
             graph[B].add(new Island(A, C));
             right = Math.max(right, C);
+        }
+
+        // 그래프 간선 정렬 (가중치 기준 내림차순)
+        for (int i = 1; i <= N; i++) {
+            graph[i].sort((a, b) -> b.weight - a.weight);
         }
 
         st = new StringTokenizer(br.readLine());
         int start = Integer.parseInt(st.nextToken());
         int end = Integer.parseInt(st.nextToken());
 
-
-        while (left <= right) { 
+        while (left <= right) {
             int mid = (left + right) / 2;
             if (bfs(graph, N, start, end, mid)) {
                 left = mid + 1;
@@ -45,12 +46,13 @@ class Main {
     }
 
     private static boolean bfs(List<Island>[] graph, int N, int start, int end, int target) {
-        PriorityQueue<Integer> pq = new PriorityQueue<>(Collections.reverseOrder());
+        Queue<Integer> queue = new LinkedList<>();
         boolean[] visited = new boolean[N + 1];
-        pq.offer(start);
+        queue.offer(start);
+        visited[start] = true;
 
-        while (!pq.isEmpty()) {
-            int curr = pq.poll();
+        while (!queue.isEmpty()) {
+            int curr = queue.poll();
             if (curr == end) {
                 return true;
             }
@@ -58,7 +60,7 @@ class Main {
             for (Island neighbor : graph[curr]) {
                 if (!visited[neighbor.num] && neighbor.weight >= target) {
                     visited[neighbor.num] = true;
-                    pq.offer(neighbor.num);
+                    queue.offer(neighbor.num);
                 }
             }
         }
@@ -70,7 +72,7 @@ class Main {
         int num;
         int weight;
 
-        Island (int num, int weight) {
+        Island(int num, int weight) {
             this.num = num;
             this.weight = weight;
         }

--- a/김승주/programmers/Graph/서울 지하철 2호선/Main.java
+++ b/김승주/programmers/Graph/서울 지하철 2호선/Main.java
@@ -1,0 +1,96 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static List<Integer>[] graph;
+    static List<Integer> innerCircles = new ArrayList<>();
+    static int[] answer;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int N = Integer.parseInt(br.readLine());
+        graph = new List[N + 1];
+        answer = new int[N + 1];
+        Arrays.fill(answer, -1);
+
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+        
+        // 순환선에 속하는 역 모두 찾기
+        List<Integer> history = new ArrayList<>();
+        history.add(1);
+        dfs(history);
+
+		// 순환선에 속하는 역에 대해 거리를 0으로 설정
+        for (int station : innerCircles) {
+            answer[station] = 0;
+        }
+
+		// 순환선에 속하는 역인데 간선이 2개보다 많다면 해당 역에서 뻗어나오는 지선이 존재한다는 뜻.
+        // -> bfs를 통해 지선에 대한 탐색 수행
+        for (int station : innerCircles) {
+            if (graph[station].size() > 2) {
+                bfs(station);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= N; i++) {
+            sb.append(answer[i]).append(" ");
+        }
+        System.out.println(sb.toString());
+    }
+
+    private static void dfs(List<Integer> history) {
+        if (!innerCircles.isEmpty()) {
+            return;
+        }
+        int curr = history.get(history.size() - 1);
+        for (int neighbor : graph[curr]) {
+        	// 이미 방문한 노드에 다시 방문했다면?
+            if (history.contains(neighbor)) {
+            	// 직전에 방문한 노드인 경우 이미 탐색한 경로이므로 스킵
+                if (history.get(history.size() - 2) == neighbor) {
+                    continue;
+                }
+                // 직전 방문 노드가 아닌 경우 -> 사이클 발견
+                for (int i = history.indexOf(neighbor); i < history.size(); i++) {
+                    innerCircles.add(history.get(i));
+                }
+                return;
+            }
+            
+            // 방문한 적 없는 노드라면 히스토리에 추가하고 계속해서 dfs 탐색 수행
+            history.add(neighbor);
+            dfs(history);
+            // 방문한 적 없는 노드에 대해 dfs를 종료했다면 해당 노드는 다시 히스토리에서 삭제
+            history.remove(history.size() - 1);
+        }
+    }
+
+    private static void bfs(int start) {
+        Queue<int[]> q = new LinkedList<>();
+        // {노드 번호, 순환선에 속하는 역과의 거리}
+        q.offer(new int[] {start, 0});
+        while (!q.isEmpty()) {
+            int[] curr = q.poll();
+            
+            for (int neighbor : graph[curr[0]]) {
+            	// 이미 거리 구한 역이면 스킵
+                if (answer[neighbor] >= 0)   continue;
+                // curr에서 한 번 더 가야 neighbor에 도달 가능
+                answer[neighbor] = curr[1] + 1;
+                // 너비를 넓혀가며 bfs를 계속 수행
+                q.offer(new int[] {neighbor, curr[1] + 1});
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 01/27

## 🔥 어려웠던 문제
### 1939 중량 제한
- 탐색의 효율성을 위해 이분 탐색을 적용할 수 있다는 걸 처음 알았어요.
그리고 처음에는 한 번 방문한 노드는 다시 탐색 안 하도록 구현했었는데, 그렇게 하니까 뒤쪽에 해당 노드를 지나면서도 더 높은 중량 제한으로 갈 수 있는 경로가 나오더라도 무시되어 버리는 문제가 있었어요.
그래서 우선순위 큐와 간선 정렬 같은 방식을 이용해서 어떤 노드를 지나는 가장 우선순위가 높은 중량의 경로를 먼저 탐색한 후 그 노드에 다시 방문하지 않도록 하는 형태로 수정을 했습니다.

## 😎 기록하고 싶은 점
- 스터디원들과 나누고 싶은 내용을 적어주세요 !

## ✅ 푼 문제
- [x] [BOJ 15681번: 트리와 쿼리](https://www.acmicpc.net/problem/15681)
- [x] [BOJ 16947번: 서울 지하철 2호선](https://www.acmicpc.net/problem/16947)
- [x] [BOJ 1939번: 중량제한](https://www.acmicpc.net/problem/1939)
- [ ] [BOJ 1517번: 버블소트](https://www.acmicpc.net/problem/1517)